### PR TITLE
SW-28 Allowed specifying multiple classes in @Map(of=...) parameter

### DIFF
--- a/src/main/java/pl/jsolve/sweetener/collection/Collections.java
+++ b/src/main/java/pl/jsolve/sweetener/collection/Collections.java
@@ -1,6 +1,7 @@
 package pl.jsolve.sweetener.collection;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -167,6 +168,14 @@ public final class Collections {
 			}
 		}
 		return (T) uniques;
+	}
+
+	public static <T extends Collection<?>> boolean containsAny(T collectionA, T collectionB) {
+		return !java.util.Collections.disjoint(collectionA, collectionB);
+	}
+
+	public static <E, T extends Collection<E>> boolean containsAny(T collection, E[] elements) {
+		return containsAny(collection, Arrays.asList(elements));
 	}
 
 	// List

--- a/src/main/java/pl/jsolve/sweetener/mapper/annotationDriven/MapAnnotationMapping.java
+++ b/src/main/java/pl/jsolve/sweetener/mapper/annotationDriven/MapAnnotationMapping.java
@@ -5,6 +5,7 @@ import static pl.jsolve.sweetener.core.Reflections.isFieldPresent;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import pl.jsolve.sweetener.collection.Collections;
 import pl.jsolve.sweetener.converter.TypeConverter;
 import pl.jsolve.sweetener.core.Reflections;
 import pl.jsolve.sweetener.mapper.annotationDriven.annotation.Map;
@@ -62,7 +63,7 @@ class MapAnnotationMapping implements AnnotationMapping {
 	}
 
 	private <T> boolean isMappingOfTargetObject(T targetObject, Map mapAnnotation) {
-		return Reflections.getClasses(targetObject).contains(mapAnnotation.of());
+		return Collections.containsAny(Reflections.getClasses(targetObject), mapAnnotation.of());
 	}
 
 	private String getTargetFieldName(Field field, Map mapAnnotation) {
@@ -81,7 +82,7 @@ class MapAnnotationMapping implements AnnotationMapping {
 
 	private void throwExceptionWhenFieldIsNotPresent(Object object, String fieldName) {
 		if (!isFieldPresent(object, fieldName)) {
-			throw new MappingException("%s does not contain field '%s'. Perhaps you misspelled field name in @Map(...) annotation?",
+			throw new MappingException("%s does not contain field '%s'. Perhaps you have misspelled field name in @Map annotation?",
 					object.getClass(), fieldName);
 		}
 	}

--- a/src/main/java/pl/jsolve/sweetener/mapper/annotationDriven/annotation/Map.java
+++ b/src/main/java/pl/jsolve/sweetener/mapper/annotationDriven/annotation/Map.java
@@ -13,5 +13,5 @@ public @interface Map {
 
 	String to() default "";
 
-	Class<?> of() default Object.class;
+	Class<?>[] of() default Object.class;
 }

--- a/src/test/java/pl/jsolve/sweetener/collection/CollectionsTest.java
+++ b/src/test/java/pl/jsolve/sweetener/collection/CollectionsTest.java
@@ -10,6 +10,7 @@ import static pl.jsolve.sweetener.tests.stub.hero.HeroProfiledBuilder.anIronMan;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -25,11 +26,11 @@ import org.junit.rules.ExpectedException;
 
 import pl.jsolve.sweetener.collection.data.Person;
 import pl.jsolve.sweetener.exception.InvalidArgumentException;
+import pl.jsolve.sweetener.tests.catcher.ExceptionalOperation;
+import pl.jsolve.sweetener.tests.stub.hero.Hero;
 import pl.jsolve.sweetener.tests.stub.person.Department;
 import pl.jsolve.sweetener.tests.stub.person.FieldOfStudy;
 import pl.jsolve.sweetener.tests.stub.person.Student;
-import pl.jsolve.sweetener.tests.catcher.ExceptionalOperation;
-import pl.jsolve.sweetener.tests.stub.hero.Hero;
 
 public class CollectionsTest {
 
@@ -216,7 +217,7 @@ public class CollectionsTest {
 		assertThat(pagination.getNumberOfPages()).isEqualTo(1);
 		assertThat(pagination.getElementsOfPage()).containsOnly("A", "B", "C", "D", "E", "F", "G", "H", "I");
 	}
-	
+
 	@Test
 	public void shouldPaginateTheCollection4() {
 		// given
@@ -370,7 +371,7 @@ public class CollectionsTest {
 				new GroupKey(7, FieldOfStudy.COMPUTER_SCIENCE, Department.AEI));
 		assertThat(groups.get(new GroupKey(3, FieldOfStudy.MATHS, Department.AEI))).onProperty("lastName").contains("Deep");
 		assertThat(groups.get(new GroupKey(3, FieldOfStudy.BIOINFORMATICS, Department.AEI))).onProperty("lastName")
-				.contains("Duke", "Knee");
+		.contains("Duke", "Knee");
 		assertThat(groups.get(new GroupKey(5, FieldOfStudy.BIOINFORMATICS, Department.MT))).onProperty("lastName").contains("Hunt");
 		assertThat(groups.get(new GroupKey(7, FieldOfStudy.COMPUTER_SCIENCE, Department.AEI))).onProperty("lastName").contains("Sky");
 	}
@@ -405,6 +406,32 @@ public class CollectionsTest {
 		// then
 		assertThat(uniques).hasSize(1);
 		assertThat(uniques).onProperty("name").contains("John");
+	}
+
+	@Test
+	public void shouldContainAny() {
+		// given
+		Collection<String> collectionA = Collections.newArrayList("Adam", "Mark", "Tom");
+		Collection<String> collectionB = Collections.newArrayList("Mat", "Mark", "Thomas");
+
+		// when
+		boolean result = Collections.containsAny(collectionA, collectionB);
+
+		// then
+		assertThat(result).as("both collections contain 'Mark'").isTrue();
+	}
+
+	@Test
+	public void shouldNotContainAny() {
+		// given
+		Collection<String> collectionA = Collections.newArrayList("Adam", "Mark", "Tom");
+		Collection<String> collectionB = Collections.newArrayList("Mat", "Marcus", "Thomas");
+
+		// when
+		boolean result = Collections.containsAny(collectionA, collectionB);
+
+		// then
+		assertThat(result).as("collections do not have common elements").isFalse();
 	}
 
 	@Test

--- a/src/test/java/pl/jsolve/sweetener/tests/stub/person/Person.java
+++ b/src/test/java/pl/jsolve/sweetener/tests/stub/person/Person.java
@@ -7,17 +7,20 @@ public class Person {
 
 	@Map
 	protected String firstName;
+
 	@Mappings({
 		@Map(to = "lastName", of = StudentSnapshot.class),
 		@Map(to = "surname", of = StudentDTO.class)
 	})
 	protected String lastName;
+
 	@Map(of = StudentSnapshot.class)
 	private int age;
+
 	@Mappings({
 		@Map(fromNested = "city.name", to = "address", of = StudentSnapshot.class),
 		@Map(fromNested = "city.population", to = "population", of = StudentSnapshot.class),
-		@Map(fromNested = "street", to = "street")
+		@Map(fromNested = "street", to = "street", of = { StudentSnapshot.class, StudentDTO.class })
 	})
 	private Address address;
 
@@ -52,5 +55,4 @@ public class Person {
 	public void setAddress(Address address) {
 		this.address = address;
 	}
-
 }


### PR DESCRIPTION
Related issue: #49 

You can now specify multiple classes in `@Map(of=...)` parameter.
So you can write:

``` java
   @Map(to = "bar", of = {A.class, B.class})
   Bar bar;
```

instead of:

``` java
   @Mappings({
      @Map(to = "bar", of = A.class),
      @Map(to = "bar", of = B.class)
   })
   Bar bar;
```
