### PR TITLE
Date and Calendar conversions supported

### DIFF
--- a/src/main/java/pl/jsolve/sweetener/converter/CalendarToDateConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/CalendarToDateConverter.java
@@ -1,0 +1,12 @@
+package pl.jsolve.sweetener.converter;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class CalendarToDateConverter implements Converter<Calendar, Date> {
+
+	@Override
+	public Date convert(Calendar source) {
+		return source.getTime();
+	}
+}

--- a/src/main/java/pl/jsolve/sweetener/converter/CalendarToLongConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/CalendarToLongConverter.java
@@ -1,0 +1,11 @@
+package pl.jsolve.sweetener.converter;
+
+import java.util.Calendar;
+
+public class CalendarToLongConverter implements Converter<Calendar, Long> {
+
+	@Override
+	public Long convert(Calendar source) {
+		return source.getTimeInMillis();
+	}
+}

--- a/src/main/java/pl/jsolve/sweetener/converter/DateToCalendarConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/DateToCalendarConverter.java
@@ -1,0 +1,14 @@
+package pl.jsolve.sweetener.converter;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class DateToCalendarConverter implements Converter<Date, Calendar> {
+
+	@Override
+	public Calendar convert(Date source) {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(source);
+		return calendar;
+	}
+}

--- a/src/main/java/pl/jsolve/sweetener/converter/DateToLongConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/DateToLongConverter.java
@@ -1,0 +1,11 @@
+package pl.jsolve.sweetener.converter;
+
+import java.util.Date;
+
+public class DateToLongConverter implements Converter<Date, Long> {
+
+	@Override
+	public Long convert(Date source) {
+		return source.getTime();
+	}
+}

--- a/src/main/java/pl/jsolve/sweetener/converter/LongToCalendarConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/LongToCalendarConverter.java
@@ -1,0 +1,13 @@
+package pl.jsolve.sweetener.converter;
+
+import java.util.Calendar;
+
+public class LongToCalendarConverter implements Converter<Long, Calendar> {
+
+	@Override
+	public Calendar convert(Long source) {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTimeInMillis(source);
+		return calendar;
+	}
+}

--- a/src/main/java/pl/jsolve/sweetener/converter/LongToDateConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/LongToDateConverter.java
@@ -1,0 +1,11 @@
+package pl.jsolve.sweetener.converter;
+
+import java.util.Date;
+
+public class LongToDateConverter implements Converter<Long, Date> {
+
+	@Override
+	public Date convert(Long source) {
+		return new Date(source);
+	}
+}

--- a/src/main/java/pl/jsolve/sweetener/converter/TypeConverter.java
+++ b/src/main/java/pl/jsolve/sweetener/converter/TypeConverter.java
@@ -104,6 +104,14 @@ public final class TypeConverter {
 		registerConverter(new CollectionToTreeSetConverter());
 		registerConverter(new CollectionToListConverter());
 		registerConverter(new CollectionToLinkedListConverter());
+
+		// date
+		registerConverter(new LongToDateConverter());
+		registerConverter(new DateToLongConverter());
+		registerConverter(new LongToCalendarConverter());
+		registerConverter(new CalendarToLongConverter());
+		registerConverter(new DateToCalendarConverter());
+		registerConverter(new CalendarToDateConverter());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/pl/jsolve/sweetener/converter/TypeConverterTest.java
+++ b/src/test/java/pl/jsolve/sweetener/converter/TypeConverterTest.java
@@ -8,6 +8,8 @@ import static pl.jsolve.sweetener.tests.stub.hero.HeroProfiledBuilder.aCaptainAm
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -958,7 +960,6 @@ public class TypeConverterTest {
 		assertThat(result).contains("one", "two", "three");
 	}
 
-
 	// primitives
 
 	@Test
@@ -995,5 +996,127 @@ public class TypeConverterTest {
 
 		// then
 		assertThat(result).isEqualTo(12.0);
+	}
+
+	// date
+
+	@Test
+	public void shouldConvertLongToDate() {
+		// given
+		Long timestamp = 1220227200100L;
+
+		// when
+		Date date = TypeConverter.convert(timestamp, Date.class);
+
+		// then
+		assertThat(date.getTime()).isEqualTo(timestamp);
+	}
+
+	@Test
+	public void shouldConvertPrimitiveLongToDate() {
+		// given
+		long timestamp = 1220227200100L;
+
+		// when
+		Date date = TypeConverter.convert(timestamp, Date.class);
+
+		// then
+		assertThat(date.getTime()).isEqualTo(timestamp);
+	}
+
+	@Test
+	public void shouldConvertDateToString() {
+		// given
+		Date date = new Date(1220227200100L);
+
+		// when
+		String result = TypeConverter.convert(date, String.class);
+
+		// then
+		assertThat(result).isEqualTo(date.toString());
+	}
+
+	@Test
+	public void shouldConvertDateToLong() {
+		// given
+		Date date = new Date(1220227200100L);
+
+		// when
+		long result = TypeConverter.convert(date, long.class);
+
+		// then
+		assertThat(result).isEqualTo(date.getTime());
+	}
+
+	@Test
+	public void shouldConvertLongToCalendar() {
+		// given
+		Long timestamp = 1220227200100L;
+
+		// when
+		Calendar result = TypeConverter.convert(timestamp, Calendar.class);
+
+		// then
+		assertThat(result.getTimeInMillis()).isEqualTo(timestamp);
+	}
+
+	@Test
+	public void shouldConvertLongPrimitiveToCalendar() {
+		// given
+		long timestamp = 1220227200100L;
+
+		// when
+		Calendar result = TypeConverter.convert(timestamp, Calendar.class);
+
+		// then
+		assertThat(result.getTimeInMillis()).isEqualTo(timestamp);
+	}
+
+	@Test
+	public void shouldConvertCalendarToString() {
+		// given
+		Calendar calendar = Calendar.getInstance();
+
+		// when
+		String result = TypeConverter.convert(calendar, String.class);
+
+		// then
+		assertThat(result).isEqualTo(calendar.toString());
+	}
+
+	@Test
+	public void shouldConvertCalendarToLong() {
+		// given
+		Calendar calendar = Calendar.getInstance();
+
+		// when
+		Long result = TypeConverter.convert(calendar, Long.class);
+
+		// then
+		assertThat(result).isEqualTo(calendar.getTimeInMillis());
+	}
+
+	@Test
+	public void shouldConvertDateToCalendar() {
+		// given
+		Date date = new Date(1220227200100L);
+
+		// when
+		Calendar calendar = TypeConverter.convert(date, Calendar.class);
+
+		// then
+		assertThat(calendar.getTime()).isEqualTo(date);
+	}
+
+	@Test
+	public void shouldConvertCalendarToDate() {
+		// given
+		Calendar calendar = Calendar.getInstance();
+
+		// when
+		Date date = TypeConverter.convert(calendar, Date.class);
+
+		// then
+		assertThat(date).isEqualTo(calendar.getTime());
 	}
 }

--- a/src/test/java/pl/jsolve/sweetener/mapper/AnnotationDrivenMapperTest.java
+++ b/src/test/java/pl/jsolve/sweetener/mapper/AnnotationDrivenMapperTest.java
@@ -11,6 +11,8 @@ import static pl.jsolve.sweetener.tests.catcher.ExceptionCatcher.tryToCatch;
 import static pl.jsolve.sweetener.tests.stub.hero.HeroBuilder.aHero;
 
 import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.Test;
 
@@ -24,6 +26,8 @@ import pl.jsolve.sweetener.mapper.stub.StudentWithArrays;
 import pl.jsolve.sweetener.mapper.stub.StudentWithBadlyAnnotatedFromNestedField;
 import pl.jsolve.sweetener.mapper.stub.StudentWithBadlyAnnotatedMapTo;
 import pl.jsolve.sweetener.mapper.stub.StudentWithCollections;
+import pl.jsolve.sweetener.mapper.stub.StudentWithDates;
+import pl.jsolve.sweetener.mapper.stub.StudentWithDatesSnapshot;
 import pl.jsolve.sweetener.mapper.stub.StudentWithGradeAsInteger;
 import pl.jsolve.sweetener.mapper.stub.StudentWithGradeAsString;
 import pl.jsolve.sweetener.mapper.stub.StudentWithMapParsingIntToAnnotationMapping;
@@ -44,6 +48,8 @@ public class AnnotationDrivenMapperTest {
 
 	private static final String NICKNAME = "ironMan";
 	private static final Long ID = 1L;
+	private static final Long FIRST_SEMPTEMBER_2008_TIMESTAMP = 1220227200100L;
+	private static final Date FIRST_SEMPTEMBER_2008_DATE = new Date(FIRST_SEMPTEMBER_2008_TIMESTAMP);
 
 	@Test
 	public void shouldMapHeroToHeroSnapshot() {
@@ -310,5 +316,35 @@ public class AnnotationDrivenMapperTest {
 		// then
 		assertThat(studentWithCollections.getGrades()).containsOnly(4, 5);
 		assertThat(studentWithCollections.getSubjects()).containsOnly("Phisics", "Math");
+	}
+
+	@Test
+	public void shouldMapStudentWithDatesToItsSnapshot() {
+		StudentWithDates studentWithDates = new StudentWithDates();
+		studentWithDates.setDateAsLong(FIRST_SEMPTEMBER_2008_TIMESTAMP);
+		studentWithDates.setDate(FIRST_SEMPTEMBER_2008_DATE);
+
+		// when
+		StudentWithDatesSnapshot studentWithDatesSnapshot = AnnotationDrivenMapper.map(studentWithDates, StudentWithDatesSnapshot.class);
+
+		// then
+		assertThat(studentWithDatesSnapshot.getCalendar().getTime()).isEqualTo(studentWithDates.getDate());
+		assertThat(studentWithDatesSnapshot.getDate().getTime()).isEqualTo(studentWithDates.getDateAsLong());
+	}
+
+	@Test
+	public void shouldConvertStudentWithDatesSnapshotToStudentWithDates() {
+		// given
+		Calendar calendar = Calendar.getInstance();
+		StudentWithDatesSnapshot studentWithDatesSnapshot = new StudentWithDatesSnapshot();
+		studentWithDatesSnapshot.setCalendar(calendar);
+		studentWithDatesSnapshot.setDate(calendar.getTime());
+
+		// when
+		StudentWithDates studentWithDates = AnnotationDrivenMapper.map(studentWithDatesSnapshot, StudentWithDates.class);
+
+		// then
+		assertThat(studentWithDates.getDate()).isEqualTo(studentWithDatesSnapshot.getCalendar().getTime());
+		assertThat(studentWithDates.getDateAsLong()).isEqualTo(studentWithDatesSnapshot.getDate().getTime());
 	}
 }

--- a/src/test/java/pl/jsolve/sweetener/mapper/stub/StudentWithDates.java
+++ b/src/test/java/pl/jsolve/sweetener/mapper/stub/StudentWithDates.java
@@ -1,0 +1,32 @@
+package pl.jsolve.sweetener.mapper.stub;
+
+import java.util.Date;
+
+import pl.jsolve.sweetener.mapper.annotationDriven.annotation.Map;
+import pl.jsolve.sweetener.mapper.annotationDriven.annotation.MappableTo;
+
+@MappableTo(StudentWithDatesSnapshot.class)
+public class StudentWithDates {
+
+	@Map(to = "date")
+	private Long dateAsLong;
+
+	@Map(to = "calendar")
+	private Date date;
+
+	public Long getDateAsLong() {
+		return dateAsLong;
+	}
+
+	public void setDateAsLong(Long dateAsLong) {
+		this.dateAsLong = dateAsLong;
+	}
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+}

--- a/src/test/java/pl/jsolve/sweetener/mapper/stub/StudentWithDatesSnapshot.java
+++ b/src/test/java/pl/jsolve/sweetener/mapper/stub/StudentWithDatesSnapshot.java
@@ -1,0 +1,33 @@
+package pl.jsolve.sweetener.mapper.stub;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import pl.jsolve.sweetener.mapper.annotationDriven.annotation.Map;
+import pl.jsolve.sweetener.mapper.annotationDriven.annotation.MappableTo;
+
+@MappableTo(StudentWithDates.class)
+public class StudentWithDatesSnapshot {
+
+	@Map(to = "dateAsLong")
+	private Date date;
+
+	@Map(to = "date")
+	private Calendar calendar;
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+	public Calendar getCalendar() {
+		return calendar;
+	}
+
+	public void setCalendar(Calendar calendar) {
+		this.calendar = calendar;
+	}
+}


### PR DESCRIPTION
The following conversions are now supported by `TypeConverter`:
- `Long` <-> `java.util.Date`,
- `Long` <-> `java.util.Calendar`,
- `java.util.Date` <-> `java.util.Calendar`.

It's also an improvement for `AnnotationDrivenMapper` which uses `TypeConverter`. :octocat: 
